### PR TITLE
2.8.0 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,24 @@
 - jar output in tika-app/target/tika-app-*.jar
 - On the server `apt-get install tesseract-ocr tesseract-ocr-eng tesseract-ocr-fra` ...(and all the other useful languages, simply put `tesseract-ocr-all` for all the available languages)
 
+## Build(Tika 2.8.0)
+- Install openjdk (20 as of this writing)
+- Install Maven3 (3.9.4 as of this writing)
+- Download tika full 2.8.0 src and unzip
+- Update tika-parent/pom.xml to update dependency versions or they will fail audit due to vulnerabilities
+  - <sqlite.version>x.xx.x.x</sqlite.version> -> <sqlite.version>3.42.0.0</sqlite.version>
+  - <bouncycastle.version>x.xx</bouncycastle.version> -> <bouncycastle.version>1.76</bouncycastle.version>
+  - <snappy-java>x.x.x.x</snappy-java> -> <snappy-java>1.1.10.3</snappy-java>
+- tika-parsers have been split into various modules based on types and `jai-imageio` `<scope>test</scopes>` are to be removed from
+  - tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/pom.xml
+  - tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/pom.xml
+  - tika-parsers/tika-parsers-standard/tika-parsers-standard-package/pom.xml
+- Edit `tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-ocr-module/src/main/java/org/apache/tika/parser/ocr/TesseractOCRParser.java`, comment everything in `checkInitialization`
+- `mvn install  -Dossindex.fail=false -DskipTests=true`
+- jar output in tika-app/target/tika-app-*.jar
+- On the server `apt-get install tesseract-ocr tesseract-ocr-eng tesseract-ocr-fra` ...(and all the other useful languages, simply put `tesseract-ocr-all` for all the available languages) Note: this is currently already done in the dockerfile
+- `ocr_config.xml` options are currently set to what will pass on `content_extraction_test.exs` tests 
+
 ## Exec
 ### Default (no ocr nor extractInlineImages)
 ```

--- a/ocr-config.xml
+++ b/ocr-config.xml
@@ -1,21 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-  <service-loader loadErrorHandler="IGNORE"/>
-  <parsers>
-    <parser class="org.apache.tika.parser.DefaultParser"/>
-    <parser class="org.apache.tika.parser.pdf.PDFParser">
-        <params>
-            <param name="extractInlineImages" type="bool">true</param>
-            <param name="allowExtractionForAccessibility" type="bool">true</param>
-            <param name="catchIntermediateExceptions" type="bool">false</param>
-            <param name="extractUniqueInlineImagesOnly" type="bool">false</param>
-            <param name="catchIntermediateExceptions" type="bool">false</param>
-            <param name="ocrDPI" type="int">314</param>
-            <param name="ocrImageQuality" type="float">2.1</param>
-            <param name="ocrImageFormatName" type="string">jpeg</param>
-            <param name="ocrImageScale" type="float">1.3</param>
-            <param name="maxMainMemoryBytes" type="long">524288000</param>
-        </params>
-    </parser>
-  </parsers>
+    <service-loader loadErrorHandler="IGNORE"/>
+    <parsers>
+        <parser class="org.apache.tika.parser.DefaultParser"/>
+        <parser class="org.apache.tika.parser.pdf.PDFParser">
+            <params>
+                <!-- These two options are independent, if both are set on, we will end up with two results -->
+                <!-- OCR on extracted inline images -->
+                <param name="extractInlineImages" type="bool">true</param>
+                <!-- OCR on rendered PDF page -->
+                <param name="ocrStrategy" type="string">no_ocr</param>
+                <!--            -->
+                <param name="allowExtractionForAccessibility" type="bool">true</param>
+                <param name="extractUniqueInlineImagesOnly" type="bool">false</param>
+                <param name="catchIntermediateExceptions" type="bool">false</param>
+                <param name="ocrDPI" type="int">314</param>
+                <param name="ocrImageQuality" type="float">2.1</param>
+                <param name="ocrImageFormatName" type="string">jpeg</param>
+                <param name="ocrImageScale" type="float">1.3</param>
+                <param name="maxMainMemoryBytes" type="long">524288000</param>
+            </params>
+        </parser>
+    </parsers>
 </properties>


### PR DESCRIPTION
Upgrade to tika 2.8.0.
Updated ocr-config.xml to conform with passing tests in content extraction.
Updated jar to 2.8.0
Updated README with instructions for 2.8.0 build